### PR TITLE
fix(access): Correction taille de la modale d'accès rapide

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gouvfr/dsfr",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Système de Design de l'Etat - DSFR",
   "repository": "git@github.com:IGNF/cartes.gouv.fr-editeur-dsfr.git",
   "author": "Service d'Information du Gouvernement <maxime.beaugrand@pm.gouv.fr>",

--- a/src/dsfr/component/access/style/module/default.scss
+++ b/src/dsfr/component/access/style/module/default.scss
@@ -54,7 +54,7 @@
         @include padding(0);
 
         @include respond-from(lg) {
-          @include width(64v);
+          @include width(72v);
         }
       }
     }


### PR DESCRIPTION
Corrige taille de la modale de l'accès rapide (de 256px à 288px)